### PR TITLE
fix: remove extra closing braces in project registry telemetry

### DIFF
--- a/src/projects/index.js
+++ b/src/projects/index.js
@@ -825,8 +825,6 @@ export const projectRegistry = [
       promptComplexity: { wordCount: 28, entityCount: 5, ambiguityScore: 0.15 },
       sourceDiversityScore: 0.85,
       dataQualityDistribution: { t1: 168, t2: 210, t3: 30, t4: 12 },
-    },
-  },
       hoursSaved: {
         researchHours: 30,
         totalHoursSaved: 180,


### PR DESCRIPTION
## Summary
Fixes a malformed object in `src/projects/index.js`: one of the project registry entries had two extra closing braces (`},}`) in the middle of its `telemetry` block, which closed the object too early and left `hoursSaved` and `consumptionTime` outside the telemetry object.

## Change
- Remove the two stray `},` and `},` so the telemetry structure is valid.

## File
- `src/projects/index.js` (2 lines removed)

Made with [Cursor](https://cursor.com)